### PR TITLE
2x speed up steepest_descent

### DIFF
--- a/src/Core/Drivers/steepest_descent.jl
+++ b/src/Core/Drivers/steepest_descent.jl
@@ -182,7 +182,7 @@ function (driver::SteepestDescent)(pose::Pose)
             break
         end
 
-        if energy >= driver.eval!(backup_pose, update_forces_overwrite = true)
+        if energy >= backup_pose.state.e[:Total]
             γ *= γdec
             ProtoSyn.recoverfrom!(pose, backup_pose)
             driver_state.max_force = ProtoSyn.atmax(pose.state, :f)


### PR DESCRIPTION
This PR improves performance of Steepest_Descent driver 2-fold.

There's no need to calculate already-calculated energy and forces.
After `recoverfrom!`, both `pose` and `backup_pose` are two instances of an identical object. They have the same `.e` and `.f`. This means that we don't need to calculate energy and forces of `backup_pose` again in this iteration (https://github.com/sergio-santos-group/ProtoSyn.jl/blob/1abcc9fffb355e8937f5c28c01d7613a6d386e18/src/Core/Drivers/steepest_descent.jl#L185), because it was already calculated in the previous iteration on the `pose` object, copying it to the `backup_pose` (using `recoverfrom!`; either https://github.com/sergio-santos-group/ProtoSyn.jl/blob/1abcc9fffb355e8937f5c28c01d7613a6d386e18/src/Core/Drivers/steepest_descent.jl#L187 or https://github.com/sergio-santos-group/ProtoSyn.jl/blob/1abcc9fffb355e8937f5c28c01d7613a6d386e18/src/Core/Drivers/steepest_descent.jl#L190)

Since calculating energy and forces is the step that takes the longest time, this makes it ~2 times faster.

Could you please confirm that my understanding is correct?